### PR TITLE
Extention sign error

### DIFF
--- a/packages/sdk/sign/src/keyfile-signer.ts
+++ b/packages/sdk/sign/src/keyfile-signer.ts
@@ -1,9 +1,13 @@
 import { Keyring } from '@polkadot/keyring';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { HexString } from '@polkadot/util/types';
 import { u8aToHex } from '@polkadot/util';
 import { InvalidSignerError } from '@unique-nft/sdk/errors';
-import { SdkSigner, SignatureType, SignResult } from '@unique-nft/sdk/types';
+import {
+  SdkSigner,
+  SignatureType,
+  SignResult,
+  UnsignedTxPayload,
+} from '@unique-nft/sdk/types';
 import { KeyfileSignerOptions } from './types';
 
 export class KeyfileSigner implements SdkSigner {
@@ -29,9 +33,11 @@ export class KeyfileSigner implements SdkSigner {
     }
   }
 
-  public async sign(payload: HexString): Promise<SignResult> {
+  public async sign(unsignedTxPayload: UnsignedTxPayload): Promise<SignResult> {
     await this.unlock();
-    const signatureU8a = this.pair.sign(payload);
+    const signatureU8a = this.pair.sign(unsignedTxPayload.signerPayloadHex, {
+      withType: true,
+    });
 
     return {
       signature: u8aToHex(signatureU8a),

--- a/packages/sdk/sign/src/polkadot-signer.ts
+++ b/packages/sdk/sign/src/polkadot-signer.ts
@@ -1,5 +1,8 @@
-import { HexString } from '@polkadot/util/types';
-import { SdkSigner, SignatureType, SignResult } from '@unique-nft/sdk/types';
+import {
+  SdkSigner,
+  SignResult,
+  UnsignedTxPayload,
+} from '@unique-nft/sdk/types';
 import { BadSignatureError } from '@unique-nft/sdk/errors';
 import { PolkadotSignerOptions } from './types';
 
@@ -20,7 +23,7 @@ export class PolkadotSigner implements SdkSigner {
     return this.options.extensionDApp.web3Accounts();
   }
 
-  public async sign(payload: HexString): Promise<SignResult> {
+  public async sign(unsignedTxPayload: UnsignedTxPayload): Promise<SignResult> {
     const allAccounts = await this.getAccounts();
     let account: any;
     switch (allAccounts.length) {
@@ -36,16 +39,14 @@ export class PolkadotSigner implements SdkSigner {
     const injector = await this.options.extensionDApp.web3FromSource(
       account.meta.source,
     );
-    const signRaw = injector?.signer?.signRaw;
-    if (signRaw) {
-      const { signature } = await signRaw({
-        address: account.address,
-        data: payload,
-        type: 'bytes',
-      });
+    const signPayload = injector?.signer?.signPayload;
+    if (signPayload) {
+      const { signature } = await signPayload(
+        unsignedTxPayload.signerPayloadJSON,
+      );
       return {
         signature,
-        signatureType: SignatureType.Sr25519,
+        signatureType: account.type,
       };
     }
 

--- a/packages/sdk/sign/src/seed-signer.ts
+++ b/packages/sdk/sign/src/seed-signer.ts
@@ -1,8 +1,12 @@
 import { Keyring } from '@polkadot/keyring';
 import { KeyringPair } from '@polkadot/keyring/types';
-import { HexString } from '@polkadot/util/types';
 import { u8aToHex } from '@polkadot/util';
-import { SdkSigner, SignatureType, SignResult } from '@unique-nft/sdk/types';
+import {
+  SdkSigner,
+  SignatureType,
+  SignResult,
+  UnsignedTxPayload,
+} from '@unique-nft/sdk/types';
 import { SeedSignerOptions } from './types';
 
 export class SeedSigner implements SdkSigner {
@@ -14,8 +18,10 @@ export class SeedSigner implements SdkSigner {
     }).addFromMnemonic(options.seed);
   }
 
-  public sign(payload: HexString): Promise<SignResult> {
-    const signatureU8a = this.pair.sign(payload);
+  public sign(unsignedTxPayload: UnsignedTxPayload): Promise<SignResult> {
+    const signatureU8a = this.pair.sign(unsignedTxPayload.signerPayloadHex, {
+      withType: true,
+    });
 
     return Promise.resolve({
       signature: u8aToHex(signatureU8a),

--- a/packages/sdk/tests/collection.spec.ts
+++ b/packages/sdk/tests/collection.spec.ts
@@ -1,14 +1,18 @@
-import { u8aToHex } from '@polkadot/util';
 import { INamespace } from 'protobufjs';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { CreateCollectionArguments } from '@unique-nft/sdk/types';
 import { normalizeAddress } from '@unique-nft/sdk/utils';
+import '@unique-nft/sdk/balance';
+import '@unique-nft/sdk/extrinsics';
+import '@unique-nft/sdk/tokens';
+
 import { Sdk } from '../src/lib/sdk';
 import {
   delay,
   getDefaultSdkOptions,
   getKeyringPairs,
   getLastCollectionId,
+  signWithAccount,
   TestAccounts,
 } from './testing-utils';
 
@@ -62,12 +66,11 @@ describe(Sdk.name, () => {
       constOnChainSchema,
     });
 
-    const signature = u8aToHex(account.sign(txPayload.signerPayloadHex));
+    const signature = signWithAccount(sdk, account, txPayload.signerPayloadHex);
 
     await sdk.extrinsics.submit({
       signerPayloadJSON: txPayload.signerPayloadJSON,
       signature,
-      signatureType: account.type,
     });
 
     await delay(30_000);
@@ -92,12 +95,11 @@ describe(Sdk.name, () => {
       constData,
     });
 
-    const signature = u8aToHex(account.sign(txPayload.signerPayloadHex));
+    const signature = signWithAccount(sdk, account, txPayload.signerPayloadHex);
 
     await sdk.extrinsics.submit({
       signerPayloadJSON: txPayload.signerPayloadJSON,
       signature,
-      signatureType: account.type,
     });
 
     await delay(30_000);

--- a/packages/sdk/tests/multiple-tx.spec.ts
+++ b/packages/sdk/tests/multiple-tx.spec.ts
@@ -1,7 +1,13 @@
 import { KeyringPair } from '@polkadot/keyring/types';
+import '@unique-nft/sdk/extrinsics';
+import '@unique-nft/sdk/tokens';
+import '@unique-nft/sdk/balance';
 
-import { u8aToHex } from '@polkadot/util';
-import { getDefaultSdkOptions, getKeyringPairs } from './testing-utils';
+import {
+  getDefaultSdkOptions,
+  getKeyringPairs,
+  signWithAccount,
+} from './testing-utils';
 import { Sdk } from '../src/lib/sdk';
 
 describe('multiple TXs', () => {
@@ -22,12 +28,11 @@ describe('multiple TXs', () => {
       amount,
     });
 
-    const signature = u8aToHex(eve.sign(signerPayloadHex));
+    const signature = signWithAccount(sdk, eve, signerPayloadHex);
 
     await sdk.extrinsics.submit({
       signerPayloadJSON,
       signature,
-      signatureType: eve.type,
     });
   };
 

--- a/packages/sdk/tests/sdk.spec.ts
+++ b/packages/sdk/tests/sdk.spec.ts
@@ -1,8 +1,11 @@
-import { u8aToHex } from '@polkadot/util';
 import { Keyring } from '@polkadot/keyring';
 import { KeyringPair } from '@polkadot/keyring/types';
+import '@unique-nft/sdk/extrinsics';
+import '@unique-nft/sdk/tokens';
+import '@unique-nft/sdk/balance';
+
 import { Sdk } from '../src/lib/sdk';
-import { getDefaultSdkOptions } from './testing-utils';
+import { getDefaultSdkOptions, signWithAccount } from './testing-utils';
 
 describe(Sdk.name, () => {
   let sdk: Sdk;
@@ -34,11 +37,10 @@ describe(Sdk.name, () => {
 
     const { signerPayloadJSON, signerPayloadHex } = txPayload;
 
-    const signature = u8aToHex(alice.sign(signerPayloadHex));
+    const signature = signWithAccount(sdk, alice, signerPayloadHex);
 
     const submitPromise = sdk.extrinsics.submit({
       signature,
-      signatureType: alice.type,
       signerPayloadJSON,
     });
 

--- a/packages/sdk/tests/signers.spec.ts
+++ b/packages/sdk/tests/signers.spec.ts
@@ -82,7 +82,6 @@ describe('Sdk signers', () => {
           destination: bob.address,
           amount: 0.000001,
         });
-        console.log('unsignedTxPayload', unsignedTxPayload);
         const { signerPayloadJSON } = unsignedTxPayload;
 
         const { signature } = await sdk.extrinsics.sign(unsignedTxPayload);

--- a/packages/sdk/tests/signers.spec.ts
+++ b/packages/sdk/tests/signers.spec.ts
@@ -8,6 +8,9 @@ import {
   KeyfileSigner,
   SignerOptions,
 } from '@unique-nft/sdk/sign';
+import '@unique-nft/sdk/extrinsics';
+import '@unique-nft/sdk/tokens';
+import '@unique-nft/sdk/balance';
 import { Sdk } from '../src/lib/sdk';
 import { getDefaultSdkOptions } from './testing-utils';
 
@@ -74,21 +77,19 @@ describe('Sdk signers', () => {
       'sign ok - %s',
       async (addressName: string, signerOptions: SignerOptions) => {
         const sdk = await createSdk(signerOptions);
-        const { signerPayloadHex, signerPayloadJSON } =
-          await sdk.balance.transfer({
-            address: getAddressByName(addressName),
-            destination: bob.address,
-            amount: 0.000001,
-          });
-
-        const { signature, signatureType } = await sdk.extrinsics.sign({
-          signerPayloadHex,
+        const unsignedTxPayload = await sdk.balance.transfer({
+          address: getAddressByName(addressName),
+          destination: bob.address,
+          amount: 0.000001,
         });
+        console.log('unsignedTxPayload', unsignedTxPayload);
+        const { signerPayloadJSON } = unsignedTxPayload;
+
+        const { signature } = await sdk.extrinsics.sign(unsignedTxPayload);
 
         expect(typeof signature).toBe('string');
         await sdk.extrinsics.verifySignOrThrow({
           signature,
-          signatureType,
           signerPayloadJSON,
         });
       },
@@ -105,21 +106,18 @@ describe('Sdk signers', () => {
         signerOptions: SignerOptions,
       ) => {
         const sdk = await createSdk(signerOptions);
-        const { signerPayloadHex, signerPayloadJSON } =
-          await sdk.balance.transfer({
-            address: getAddressByName(addressName),
-            destination: getAddressByName(destinationName),
-            amount: 0.000001,
-          });
-
-        const { signature, signatureType } = await sdk.extrinsics.sign({
-          signerPayloadHex,
+        const unsignedTxPayload = await sdk.balance.transfer({
+          address: getAddressByName(addressName),
+          destination: getAddressByName(destinationName),
+          amount: 0.000001,
         });
+        const { signerPayloadJSON } = unsignedTxPayload;
+
+        const { signature } = await sdk.extrinsics.sign(unsignedTxPayload);
 
         await expect(async () => {
           await sdk.extrinsics.verifySignOrThrow({
             signature,
-            signatureType,
             signerPayloadJSON,
           });
         }).rejects.toThrowError(new BadSignatureError());
@@ -177,22 +175,19 @@ describe('Sdk signers', () => {
         },
       });
 
-      const { signerPayloadHex, signerPayloadJSON } =
-        await sdk.balance.transfer({
-          address: testUser.keyfile.address,
-          destination: bob.address,
-          amount: 0.000001,
-        });
-
-      const { signature, signatureType } = await sdk.extrinsics.sign({
-        signerPayloadHex,
+      const unsignedTxPayload = await sdk.balance.transfer({
+        address: testUser.keyfile.address,
+        destination: bob.address,
+        amount: 0.000001,
       });
+      const { signerPayloadJSON } = unsignedTxPayload;
+
+      const { signature } = await sdk.extrinsics.sign(unsignedTxPayload);
 
       expect(typeof signature).toBe('string');
 
       await sdk.extrinsics.verifySignOrThrow({
         signature,
-        signatureType,
         signerPayloadJSON,
       });
     });

--- a/packages/sdk/tests/testing-utils.ts
+++ b/packages/sdk/tests/testing-utils.ts
@@ -1,6 +1,7 @@
 import { cryptoWaitReady } from '@polkadot/util-crypto';
 import { KeyringPair } from '@polkadot/keyring/types';
 import { Keyring } from '@polkadot/keyring';
+import { HexString } from '@polkadot/util/types';
 import { SdkOptions } from '@unique-nft/sdk/types';
 import { Sdk } from '../src/lib/sdk';
 
@@ -49,3 +50,14 @@ export const getDefaultSdkOptions = (): SdkOptions => ({
   chainWsUrl: 'wss://ws-quartz-dev.unique.network',
   ipfsGatewayUrl: 'https://ipfs.unique.network/ipfs/',
 });
+
+export function signWithAccount(
+  sdk: Sdk,
+  account: KeyringPair,
+  signerPayloadHex: HexString,
+): HexString {
+  return sdk.extrinsics.packSignatureType(
+    account.sign(signerPayloadHex),
+    account.type,
+  );
+}

--- a/packages/sdk/tsconfig.lib.json
+++ b/packages/sdk/tsconfig.lib.json
@@ -9,7 +9,8 @@
     "paths": {
       "@unique-nft/sdk/*": ["packages/sdk/*"],
       "@unique-nft/sdk": ["packages/sdk/src/index.ts"]
-    }
+    },
+    "module": "ESNext"
   },
   "angularCompilerOptions": {
     "enableIvy": false

--- a/packages/sdk/tsconfig.spec.json
+++ b/packages/sdk/tsconfig.spec.json
@@ -6,5 +6,5 @@
     "types": ["jest", "node"],
     "allowJs": true
   },
-  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+  "include": ["**/*.test.ts", "**/*.spec.ts", "**/*.d.ts", "**/*.ts"]
 }

--- a/packages/sdk/types/arguments.ts
+++ b/packages/sdk/types/arguments.ts
@@ -2,10 +2,6 @@ import { SignerPayloadJSON } from '@polkadot/types/types/extrinsic';
 import { HexString } from '@polkadot/util/types';
 import { SignatureType, SignResult } from './polkadot-types';
 
-export interface SdkSigner {
-  sign(payload: string): Promise<SignResult>;
-}
-
 export interface SubmitResult {
   hash: HexString;
 }
@@ -22,7 +18,6 @@ export interface SignTxResult extends SignResult {
 export interface SubmitTxArguments {
   signerPayloadJSON: SignerPayloadJSON;
   signature: HexString;
-  signatureType: SignatureType | `${SignatureType}`;
 }
 
 export interface TxBuildArguments {

--- a/packages/sdk/types/sdk-methods.ts
+++ b/packages/sdk/types/sdk-methods.ts
@@ -10,13 +10,13 @@ import {
   TokenInfo,
 } from './unique-types';
 import {
-  SdkSigner,
   SignTxArguments,
   SignTxResult,
   SubmitResult,
   SubmitTxArguments,
   TxBuildArguments,
 } from './arguments';
+import { SignResult } from './polkadot-types';
 
 export interface ChainProperties {
   SS58Prefix: number;
@@ -121,4 +121,8 @@ export interface ISdkExtrinsics {
     signer: SdkSigner | undefined,
   ): Promise<SignTxResult>;
   submit(args: SubmitTxArguments): Promise<SubmitResult>;
+}
+
+export interface SdkSigner {
+  sign(unsignedTxPayload: UnsignedTxPayload): Promise<SignResult>;
 }

--- a/packages/sdk/types/sdk-options.ts
+++ b/packages/sdk/types/sdk-options.ts
@@ -1,4 +1,4 @@
-import { SdkSigner } from './arguments';
+import { SdkSigner } from './sdk-methods';
 
 export interface SdkOptions {
   chainWsUrl: string;

--- a/packages/web/src/app/controllers/extrinsics.controller.ts
+++ b/packages/web/src/app/controllers/extrinsics.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Post, UseFilters, Headers } from '@nestjs/common';
 
 import { Sdk } from '@unique-nft/sdk';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
-import { SdkSigner } from '@unique-nft/sdk/types';
+import { SdkSigner, UnsignedTxPayload } from '@unique-nft/sdk/types';
 import { SdkExceptionsFilter } from '../utils/exception-filter';
 import { SignHeaders, VerificationResultResponse } from '../types/requests';
 import { Signer } from '../decorators/signer.decorator';
@@ -30,7 +30,7 @@ export class ExtrinsicsController {
   @Post('sign')
   @ApiBearerAuth('SeedAuth')
   async sign(
-    @Body() args: SignTxBody,
+    @Body() args: UnsignedTxPayload,
     @Headers() headers: SignHeaders,
     @Signer() signer?: SdkSigner,
   ): Promise<SignTxResultResponse> {

--- a/packages/web/src/app/types/arguments.ts
+++ b/packages/web/src/app/types/arguments.ts
@@ -36,15 +36,11 @@ export class SubmitTxBody implements SubmitTxArguments {
   signerPayloadJSON: SignerPayloadJSONDto;
 
   @IsHexadecimal()
-  @ApiProperty({ type: String })
-  signature: HexString;
-
-  @IsEnum(SignatureType)
   @ApiProperty({
-    enum: SignatureType,
-    required: false,
+    type: String,
+    description: 'Warning: Signature must be with SignatureType!',
   })
-  signatureType: SignatureType | `${SignatureType}`;
+  signature: HexString;
 }
 
 export class TxBuildBody implements TxBuildArguments {

--- a/packages/web/tests/signers.spec.ts
+++ b/packages/web/tests/signers.spec.ts
@@ -67,14 +67,12 @@ describe('Web signers', () => {
         amount: 0.000001,
       });
     expect(true).toEqual(buildResponse.ok);
-    const { signerPayloadJSON, signerPayloadHex } = buildResponse.body;
+    const { signerPayloadJSON } = buildResponse.body;
 
     const signResponse = await request(app.getHttpServer())
       .post(`/api/extrinsic/sign`)
       .set(headers)
-      .send({
-        signerPayloadHex,
-      });
+      .send(buildResponse.body);
     expect(true).toEqual(signResponse.ok);
     const { signature } = signResponse.body;
 


### PR DESCRIPTION
Что сделано:
1.  Сигнеры на вход получают `UnsignedTxPayload` - объект, результаты выполнения метода `sdk.extrinsics.build`. Каждый сигнер берет из этого объекта то, что ему нужно для создания подписи (кто то возьмет hex-строку, а кто то json объект).
2. Сигнеры всегда возвращают подпись запакованную с типом
3. Метод sdk.extrinsics.submit всегда получает подпись запакованную с типом. Из метода выпилили параметр signatureType. 